### PR TITLE
Fix tv series minute format

### DIFF
--- a/plugins/tvseries.py
+++ b/plugins/tvseries.py
@@ -32,7 +32,7 @@ def get_next_episode_info(show):
 		info += ' - season %d, episode %d airs at %s' % (
 			nextepisode['season'],
 			nextepisode['number'],
-			dt.strftime('%Y-%m-%d %H:%I %z'),
+			dt.strftime('%Y-%m-%d %H:%M %z'),
 		)
 		now = datetime.datetime.now(dt.tzinfo)
 		if dt > now:


### PR DESCRIPTION
With strftime, %I means 12-hour format hour, not minute. Changed to %M for minute.